### PR TITLE
remove warnings

### DIFF
--- a/AeroGearSyncJsonPatch.xcodeproj/project.pbxproj
+++ b/AeroGearSyncJsonPatch.xcodeproj/project.pbxproj
@@ -18,7 +18,6 @@
 		48784C921D8036B1001382FF /* Diff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48784C801D8036B1001382FF /* Diff.swift */; };
 		48784C931D8036B1001382FF /* Document.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48784C811D8036B1001382FF /* Document.swift */; };
 		48784C941D8036B1001382FF /* Edit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48784C821D8036B1001382FF /* Edit.swift */; };
-		48784C951D8036B1001382FF /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 48784C831D8036B1001382FF /* Info.plist */; };
 		48784C961D8036B1001382FF /* InMemoryDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48784C841D8036B1001382FF /* InMemoryDataStore.swift */; };
 		48784C971D8036B1001382FF /* JsonPatchDiff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48784C851D8036B1001382FF /* JsonPatchDiff.swift */; };
 		48784C981D8036B1001382FF /* JsonPatchEdit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48784C861D8036B1001382FF /* JsonPatchEdit.swift */; };
@@ -253,7 +252,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 0730;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = AeroGear;
 				TargetAttributes = {
 					48784C5F1D803670001382FF = {
@@ -289,7 +288,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				48784C951D8036B1001382FF /* Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -439,8 +437,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -449,7 +449,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/build/Debug-iphoneos/JSONTools";
+				FRAMEWORK_SEARCH_PATHS = "";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -489,8 +489,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -499,7 +501,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/build/Debug-iphoneos/JSONTools";
+				FRAMEWORK_SEARCH_PATHS = "";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -511,6 +513,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -523,6 +526,7 @@
 			baseConfigurationReference = 48E4C401D09FE2DF939F0186 /* Pods-AeroGearSyncJsonPatch.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -545,6 +549,7 @@
 			baseConfigurationReference = C14776351B3D5FAF2BB7E9FF /* Pods-AeroGearSyncJsonPatch.release.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -565,6 +570,7 @@
 			baseConfigurationReference = 44B26480595A142B39B6D290 /* Pods-AeroGearSyncJsonPatch-AeroGearSyncJsonPatchTests.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = AeroGearSyncJsonPatchTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				ONLY_ACTIVE_ARCH = YES;

--- a/AeroGearSyncJsonPatch.xcodeproj/xcshareddata/xcschemes/AeroGearSyncJsonPatch.xcscheme
+++ b/AeroGearSyncJsonPatch.xcodeproj/xcshareddata/xcschemes/AeroGearSyncJsonPatch.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0730"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/AeroGearSyncJsonPatch/ClientSynchronizer.swift
+++ b/AeroGearSyncJsonPatch/ClientSynchronizer.swift
@@ -29,9 +29,9 @@ Differential Synchronization for a specific type of documents.
 */
 public protocol ClientSynchronizer {
     
-    typealias T
-    typealias D: Edit
-    typealias P: PatchMessage
+    associatedtype T
+    associatedtype D: Edit
+    associatedtype P: PatchMessage
     
     /**
     Called when the shadow should be patched. Is called when an update is recieved.

--- a/AeroGearSyncJsonPatch/DataStore.swift
+++ b/AeroGearSyncJsonPatch/DataStore.swift
@@ -27,8 +27,8 @@ Differential Synchronization implementation.
 */
 public protocol DataStore {
     
-    typealias T
-    typealias D
+    associatedtype T
+    associatedtype D
 
     /**
     Saves a client document.

--- a/AeroGearSyncJsonPatch/Edit.swift
+++ b/AeroGearSyncJsonPatch/Edit.swift
@@ -22,7 +22,7 @@ Represents a single edit. The typealias D refer to the type of the Diff comaptib
 */
 public protocol Edit: Equatable, CustomStringConvertible {
 
-    typealias D
+    associatedtype D
     
     /**
     The clientId to identifie which client it is related to.

--- a/AeroGearSyncJsonPatch/PatchMesssage.swift
+++ b/AeroGearSyncJsonPatch/PatchMesssage.swift
@@ -27,7 +27,7 @@ Edits that represent updates to be performed on the opposing sides document.
 */
 public protocol PatchMessage: CustomStringConvertible, Payload {
     
-    typealias E: Edit
+    associatedtype E: Edit
     
     /**
     Identifies the document that this edit is related to.

--- a/AeroGearSyncJsonPatch/Payload.swift
+++ b/AeroGearSyncJsonPatch/Payload.swift
@@ -24,7 +24,7 @@ Represents something that can be exchanged in JSON format.
 */
 public protocol Payload {
     
-    typealias T
+    associatedtype T
     
     /**
     Transforms this payload to a JSON String representation.
@@ -38,5 +38,5 @@ public protocol Payload {
     - parameter json: a string representation of this payloads type.
     - returns: T an instance of this payloads type.
     */
-    func fromJson(var json:String) -> T?
+    func fromJson(json:String) -> T?
 }


### PR DESCRIPTION
@jcesarmobile I followed Xcode warnings removal suggestion
Let's do the rename to fix the deprecated warning in Swift2.3
